### PR TITLE
Fix markers when using backwards query

### DIFF
--- a/aio_sqlakeyset/results.py
+++ b/aio_sqlakeyset/results.py
@@ -160,6 +160,7 @@ class Paging:
         four = [self.marker_0, self.marker_1, self.marker_n, self.marker_nplus1]
 
         if backwards:
+            self.markers.reverse()
             self.rows.reverse()
             four.reverse()
 


### PR DESCRIPTION
When using a reversed query ("previous page"), the rows are reversed -- And the markers need to be reversed too!