### PR TITLE
Update pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,21 +7,16 @@ Notes:
 was removed completely.
 2. The interface for paging is different from the original interface. It now supports previous, first, last, next on paging.
 
-## How to build and publish
-- First setup repository for poetry to push to. To do that, run the following command `poetry config repositories.gitlab https://gitlab.com/api/v4/projects/<project_id>/packages/pypi`.
-- Now setup credentials for that repository. `poetry config http-basic.gitlab <access token name> <acess token>`
-- Build the package by running `poetry build`
-- Publish the package by running `poetry publish --repository gitlab`
-
 ## How to install
  - If you're using poetry, add the following block to your pyproject.toml file.
 
 ```
-[[tool.poetry.source]]
-name = "gitlab"
-url = "https://gitlab.com/api/v4/projects/<project_id>/packages/pypi/simple"
+[tool.poetry.dependencies]
+aio_sqlakeyset = {git = "https://github.com/virgodesigns/sqlakeyset", rev = "master"}
 ```
-and then run `poetry config http-basic.gitlab <access token name> <acess token>`
-- If you're using pip, you can install using:
-`pip install aio-sqlakeyset --no-deps --index-url https://<access token name>:<access token password>/api/v4/projects/<project_id>/packages/pypi/simple` or you can update similar config in global `pip.conf` file.
 
+- If you're using pip, you can install using:
+
+```
+pip install git+https://github.com/virgodesigns/sqlakeyset@master
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,25 +4,31 @@ version = "1.0"
 authors = [ "Robert Lechte <robertlechte@gmail.com>",]
 license = "Unlicense"
 description = "offset-free paging for sqlalchemy"
+packages = [
+    { include = "aio_sqlakeyset" },
+]
 
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.dependencies]
-python = ">=3.7"
-sqlalchemy = ">=1.3.11"
+python = ">=3.7 <4.0"
+sqlalchemy = ">=1.4"
 python-dateutil = "*"
-packaging = ">=20.0"
 
 [tool.poetry.dev-dependencies]
-sqlbag = "git+https://github.com/djrobstep/sqlbag.git@f4759318710ef33dc041710a6ff38f03d3c39b56"
+sqlbag = "*"
+packaging = ">=20.0"
 pytest = "*"
 pytest-cov = "*"
-pytest-clarity = ">=0.3.0-alpha.0"
+pytest-clarity = "*"
 psycopg2-binary = "*"
 pymysql = "*"
 flake8 = "*"
 isort = "*"
 pytz = "*"
-black = { version = ">=19.10b0", python=">=3.6" }
+black = "*"
 sqlalchemy_utils = "*"
 arrow = "*"
 


### PR DESCRIPTION
In particular:
- forces sqlalchemy >= 1.4 (Which is the point of this fork)
- uses the pypi package for of sqlbag (poetry didn't like the git commit syntax used for it, but that commit has been merged into the official package since)
- Move `packaging` into dev dependencies
- Support installing directly with `pip install git+....`

Since it is now possible to add poetry/pip dependency to this package directly using the git url, I have updated the readme and completely removed the `publish` section. Let me know if this was a bad idea.

Btw, this package should be published in pypi instead of a private gitlab repository ;)